### PR TITLE
Update station id trips

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ namespace :db do
   require_relative "db/seeds"
   desc "Import CSV to table"
   task :import_csv => :environment do
-    # import_station_csv
+    import_station_csv
   
     import_trip_csv
   end

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -1,7 +1,7 @@
 class Station < ActiveRecord::Base 
 
-  has_many :start_trips , class_name: "Trip", primary_key: "csv_id", foreign_key: "start_station_id"
-  has_many :end_trips , class_name: "Trip", primary_key: "csv_id", foreign_key: "end_station_id"
+  has_many :start_trips , class_name: "Trip", foreign_key: "start_station_id"
+  has_many :end_trips , class_name: "Trip", foreign_key: "end_station_id"
 
   validates :name, :dock_count, :city_id, :installation_date, presence: true
 

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -1,6 +1,10 @@
-class Station < ActiveRecord::Base
+class Station < ActiveRecord::Base 
+  validates :name,
+            :dock_count,
+            :city_id,
+            :installation_date,
+              presence: true
   belongs_to :city
-  validates :name, :dock_count, :city_id, :installation_date, presence: true
 
   def self.write(station_details)
     self.find_or_create_by(name: station_details[:name],

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -10,22 +10,23 @@ class Trip < ActiveRecord::Base
             :zipcode,
                presence: true
   belongs_to :subscription
-  belongs_to :start_station , class_name: "Station", primary_key: "csv_id", foreign_key: "start_station_id"
-  belongs_to :end_station , class_name: "Station", primary_key: "csv_id", foreign_key: "end_station_id"
+  belongs_to :start_station, class_name: "Station", foreign_key: "start_station_id"
+  belongs_to :end_station, class_name: "Station", foreign_key: "end_station_id"
 
   def self.import(trip_details)
+    Trip.delete_all
     self.create(subscription_id: find_subscription_id(trip_details[:subscription_name]),
                 duration: trip_details[:duration],
                 start_date: trip_details[:start_date],
-                start_station_id: trip_details[:start_station_id],
-                end_station_id: trip_details[:end_station_id],
+                start_station_id: find_station_id(trip_details[:start_station_name]),
+                end_station_id: find_station_id(trip_details[:end_station_name]),
                 end_date: trip_details[:end_date],
                 bike_id: trip_details[:bike_id],
                 zipcode: trip_details[:zipcode])
   end
   
   def self.write(trip_details)
-    self.create(subscription_id: find_subscription_id(trip_details[:subscription_name]),
+    self.find_or_create_by(subscription_id: find_subscription_id(trip_details[:subscription_name]),
                           duration: trip_details[:duration],
                           start_date: trip_details[:start_date],
                           start_station_id: find_station_id(trip_details[:start_station_name]),
@@ -55,7 +56,7 @@ class Trip < ActiveRecord::Base
   def self.station_with_most_rides_as_starting_place
     start_station_id_count_list = trip_count_for_stations_as_starting_place_all
     start_station_id = start_station_id_count_list.first.first
-    Station.find_by(csv_id: start_station_id)
+    Station.find(start_station_id)
   end
 
   def self.most_ridden_bike_with_total_number_of_rides_for_that_bike_all

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -15,8 +15,8 @@ class Trip < ActiveRecord::Base
     self.find_or_create_by(subscription_id: find_subscription_id(trip_details[:subscription_name]),
                           duration: trip_details[:duration],
                           start_date: trip_details[:start_date],
-                          start_station_id: trip_details[:start_station_id],
-                          end_station_id: trip_details[:end_station_id],
+                          start_station_id: find_station_id(trip_details[:start_station_id]),
+                          end_station_id: find_station_id(trip_details[:end_station_id]),
                           end_date: trip_details[:end_date],
                           bike_id: trip_details[:bike_id],
                           zipcode: trip_details[:zipcode])
@@ -24,6 +24,10 @@ class Trip < ActiveRecord::Base
 
   def self.find_subscription_id(subscription_type)
     Subscription.write(name: subscription_type).id
+  end
+
+  def self.find_station_id(station_name)
+    Station.find_by(name: station_name).id
   end
 
 end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -15,8 +15,8 @@ class Trip < ActiveRecord::Base
     self.find_or_create_by(subscription_id: find_subscription_id(trip_details[:subscription_name]),
                           duration: trip_details[:duration],
                           start_date: trip_details[:start_date],
-                          start_station_id: find_station_id(trip_details[:start_station_id]),
-                          end_station_id: find_station_id(trip_details[:end_station_id]),
+                          start_station_id: find_station_id(trip_details[:start_station_name]),
+                          end_station_id: find_station_id(trip_details[:end_station_name]),
                           end_date: trip_details[:end_date],
                           bike_id: trip_details[:bike_id],
                           zipcode: trip_details[:zipcode])
@@ -27,6 +27,7 @@ class Trip < ActiveRecord::Base
   end
 
   def self.find_station_id(station_name)
+    return "This station has not been added to the database yet" if Station.find_by(name: station_name).nil?
     Station.find_by(name: station_name).id
   end
 

--- a/app/views/stations/edit.erb
+++ b/app/views/stations/edit.erb
@@ -2,7 +2,7 @@
 <input type = "hidden" name = "_method" value = "put"/>
 <input name = "stations[name]" value = "<%= @station.name %>" />
 <input name = "stations[dock_count]" value = "<%= @station.dock_count %>" />
-<input name = "stations[city_id]" value = "<%= @station.city.id %>" />
+<input name = "stations[city_name]" value = "<%= City.find(@station.city_id) %>" />
 <input name = "stations[installation_date]" value = "<%=@station.installation_date %>" />
 <input type = "submit" value = "Submit">
 </form>

--- a/app/views/trips/new.erb
+++ b/app/views/trips/new.erb
@@ -11,7 +11,7 @@
   </div>
   <div class="form-group">
     <label>Starting Station</label>
-    <input class="form-control" type="integer" name="trips[start_station_id]">
+    <input class="form-control" type="integer" name="trips[start_station_name]">
   </div>
   <div class="form-group">
     <label>End Date and Time</label>
@@ -19,7 +19,7 @@
   </div>
   <div class="form-group">
     <label>Ending Station</label>
-    <input class="form-control" type="integer" name="trips[end_station_id]">
+    <input class="form-control" type="integer" name="trips[end_station_name]">
   </div>
   <div class="form-group">
     <label>Bike ID</label>

--- a/db/migrate/20161207035256_drop_station_table.rb
+++ b/db/migrate/20161207035256_drop_station_table.rb
@@ -1,0 +1,5 @@
+class DropStationTable < ActiveRecord::Migration[5.0]
+  def change
+    drop_table :stations
+  end
+end

--- a/db/migrate/20161207035352_recreate_stations_table.rb
+++ b/db/migrate/20161207035352_recreate_stations_table.rb
@@ -1,0 +1,14 @@
+class RecreateStationsTable < ActiveRecord::Migration[5.0]
+  def change
+    create_table :stations do |t|
+      t.string :name
+      t.float :lat
+      t.float :long
+      t.integer :dock_count
+      t.integer :city_id
+      t.date :installation_date
+
+      t.timestamps null:false
+    end
+  end
+end

--- a/db/migrate/20161207173824_remove_csv_id_station.rb
+++ b/db/migrate/20161207173824_remove_csv_id_station.rb
@@ -1,0 +1,5 @@
+class RemoveCsvIdStation < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :stations, :csv_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,6 @@
 
 ActiveRecord::Schema.define(version: 20161207050055) do
 
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161206232118) do
+ActiveRecord::Schema.define(version: 20161207035352) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161207050055) do
+ActiveRecord::Schema.define(version: 20161207173824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20161207050055) do
 
   create_table "conditions", force: :cascade do |t|
     t.date    "date"
+    t.string  "events"
     t.integer "max_temperature_f"
     t.integer "mean_temperature_f"
     t.integer "min_temperature_f"
@@ -32,18 +33,17 @@ ActiveRecord::Schema.define(version: 20161207050055) do
     t.integer "max_humidity"
     t.integer "mean_humidity"
     t.integer "min_humidity"
-    t.float   "max_sea_level_pressure_inches"
-    t.float   "mean_sea_level_pressure_inches"
-    t.float   "min_sea_level_pressure_inches"
+    t.integer "max_sea_level_pressure_inches"
+    t.integer "mean_sea_level_pressure_inches"
+    t.integer "min_sea_level_pressure_inches"
     t.integer "max_visibility_miles"
     t.integer "mean_visibility_miles"
     t.integer "min_visibility_miles"
     t.integer "max_wind_speed_mph"
     t.integer "mean_wind_speed_mph"
-    t.integer "max_gust_speed_mph"
-    t.float   "precipitation_inches"
+    t.integer "min_wind_speed_mph"
+    t.integer "precipitation_inches"
     t.integer "cloud_cover"
-    t.string  "events"
     t.integer "wind_dir_degrees"
     t.integer "zip_code"
   end
@@ -57,7 +57,6 @@ ActiveRecord::Schema.define(version: 20161207050055) do
     t.date     "installation_date"
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
-    t.integer  "csv_id"
   end
 
   create_table "subscriptions", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,8 +28,8 @@ def import_trip_csv
   CSV.foreach('db/csv/trip.csv', :headers=> true) do |row|
     Trip.write({duration: row['duration'],
                 start_date: time_fix(row['start_date']),
-                start_station_id: row['start_station_id'],
-                end_station_id: row['end_station_id'],
+                start_station_name: row['start_station_name'],
+                end_station_name: row['end_station_name'],
                 end_date: time_fix(row['end_date']),
                 bike_id: row['bike_id'],
                 subscription_type: row['subscription_type'],

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,8 +12,6 @@ end
 
 def import_station_csv
   CSV.foreach('db/csv/station.csv', :headers=> true) do |row|
-
-
     Station.write({name: row["name"],
                    lat: row["lat"],
                    long: row["long"],

--- a/spec/features/user_adds_trip_spec.rb
+++ b/spec/features/user_adds_trip_spec.rb
@@ -7,9 +7,9 @@ describe "When a user visits the new trip path" do
 
     fill_in 'trips[duration]', with: 45
     fill_in 'trips[start_date]', with: "2013-6-6"
-    fill_in 'trips[start_station_id]', with: 2
+    fill_in 'trips[start_station_name]', with: "TestStation1"
     fill_in 'trips[end_date]', with: "2013-6-6"
-    fill_in 'trips[end_station_id]', with: 4
+    fill_in 'trips[end_station_name]', with: "TestStaton2"
     fill_in 'trips[bike_id]', with: 3
     fill_in 'trips[subscription_name]', with: "Subscriber"
     fill_in 'trips[zipcode]', with: 80211

--- a/spec/models/station_spec.rb
+++ b/spec/models/station_spec.rb
@@ -332,66 +332,47 @@ describe "Station" do
   end
   describe "Database relations" do
     it "Returns lits of Trip objects where station was start station for trip" do
-      test_trip1 = Trip.write(duration: 90,
-                                start_date: "2011-3-6 12:00",
-                                start_station_id: 1,
-                                end_date: "2011-3-6 12:00",
-                                end_station_id: 3,
-                                bike_id: 3,
-                                subscription_type: "Subscriber", 
-                                zipcode: 80211)
-      test_trip2 = Trip.write(duration: 100,
-                                start_date: "2012-2-2 12:00",
-                                start_station_id: 10,
-                                end_date: "2012-2-6 12:00",
-                                end_station_id: 3,
-                                bike_id: 6,
-                                subscription_type: "Subscriber", 
-                                zipcode: 80222)
-      test_start_station = Station.write(name: "TestStation1",
+      test_start_station = Station.write(name: "StartStation",
                                         lat: 1.1,
                                         long: 1.2,
                                         dock_count: 1,
                                         city_name: "TestCityName1",
                                         installation_date: "2011-11-11",
-                                        csv_id: 1
                                         )
-      test_end_station = Station.write(name: "TestStation3",
+      test_end_station = Station.write(name: "EndStation",
                                         lat: 3.1,
                                         long: 3.2,
                                         dock_count: 3,
                                         city_name: "TestCityName3",
                                         installation_date: "2011-11-11",
-                                        csv_id: 3
                                         )
+      test_trip1 = Trip.write(duration: 90,
+                              start_date: "2011-3-6 12:00",
+                              start_station_name: "StartStation",
+                              end_date: "2011-3-6 12:00",
+                              end_station_name: "EndStation",
+                              bike_id: 3,
+                              subscription_type: "Subscriber", 
+                              zipcode: 80211)
+      test_trip2 = Trip.write(duration: 100,
+                              start_date: "2012-2-2 12:00",
+                              start_station_name: "StartStation",
+                              end_date: "2012-2-6 12:00",
+                              end_station_name: "EndStation",
+                              bike_id: 6,
+                              subscription_type: "Subscriber", 
+                              zipcode: 80222)
 
-      expect(test_start_station.start_trips.count).to eq(1)
+      expect(test_start_station.start_trips.count).to eq(2)
       expect(test_start_station.start_trips.first.duration).to eq(test_trip1.duration)
     end
     it "Returns lits of Trip objects where station was end station for trip" do
-      test_trip1 = Trip.write(duration: 90,
-                                start_date: "2011-3-6 12:00",
-                                start_station_id: 1,
-                                end_date: "2011-3-6 12:00",
-                                end_station_id: 3,
-                                bike_id: 3,
-                                subscription_type: "Subscriber", 
-                                zipcode: 80211)
-      test_trip2 = Trip.write(duration: 100,
-                                start_date: "2012-2-2 12:00",
-                                start_station_id: 10,
-                                end_date: "2012-2-6 12:00",
-                                end_station_id: 3,
-                                bike_id: 6,
-                                subscription_type: "Subscriber", 
-                                zipcode: 80222)
-      test_start_station = Station.write(name: "TestStation1",
+            test_start_station = Station.write(name: "TestStation1",
                                         lat: 1.1,
                                         long: 1.2,
                                         dock_count: 1,
                                         city_name: "TestCityName1",
                                         installation_date: "2011-11-11",
-                                        csv_id: 1
                                         )
       test_end_station = Station.write(name: "TestStation3",
                                         lat: 3.1,
@@ -399,8 +380,23 @@ describe "Station" do
                                         dock_count: 3,
                                         city_name: "TestCityName3",
                                         installation_date: "2011-11-11",
-                                        csv_id: 3
                                         )
+      test_trip1 = Trip.write(duration: 90,
+                                start_date: "2011-3-6 12:00",
+                                start_station_name: "TestStation1",
+                                end_date: "2011-3-6 12:00",
+                                end_station_name: "TestStation3",
+                                bike_id: 3,
+                                subscription_name: "Subscriber", 
+                                zipcode: 80211)
+      test_trip2 = Trip.write(duration: 100,
+                                start_date: "2012-2-2 12:00",
+                                start_station_name: "TestStation1",
+                                end_date: "2012-2-6 12:00",
+                                end_station_name: "TestStation3",
+                                bike_id: 6,
+                                subscription_type: "Subscriber", 
+                                zipcode: 80222)
 
       expect(test_end_station.end_trips.count).to eq(2)
       expect(test_end_station.end_trips.first.duration).to eq(test_trip1.duration)

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -117,44 +117,51 @@ describe "Trip" do
     end
     describe "Stations with most rides as starting place" do
       it "Return Station object from which most rides started from" do
-        test_trip1 = Trip.write(duration: 90,
-                                  start_date: "2011-3-6 12:00",
-                                  start_station_id: 1,
-                                  end_date: "2011-3-6 12:00",
-                                  end_station_id: 3,
-                                  bike_id: 3,
-                                  subscription_type: "Subscriber", 
-                                  zipcode: 80211)
-        test_trip2 = Trip.write(duration: 100,
-                                  start_date: "2012-2-2 12:00",
-                                  start_station_id: 10,
-                                  end_date: "2012-2-6 12:00",
-                                  end_station_id: 3,
-                                  bike_id: 6,
-                                  subscription_type: "Subscriber", 
-                                  zipcode: 80222)
-        test_trip3 = Trip.write(duration: 200,
-                                  start_date: "2013-3-3 12:00",
-                                  start_station_id: 10,
-                                  end_date: "2013-3-6 12:00",
-                                  end_station_id: 15,
-                                  bike_id: 4,
-                                  subscription_type: "Subscriber", 
-                                  zipcode: 80333)
+        test_station1 = Station.write(name: "TestStation1",
+                                      lat: 1.1,
+                                      long: 1.2,
+                                      dock_count: 1,
+                                      city_name: "TestCityName1",
+                                      installation_date: "2011-11-11",
+                                      )
         test_station10 = Station.write(name: "TestStation10",
                                         lat: 1.1,
                                         long: 1.2,
                                         dock_count: 10,
                                         city_name: "TestCityName10",
                                         installation_date: "2011-11-11",
-                                        csv_id: 10)
+                                        )
         test_station3 = Station.write(name: "TestStation3",
                                       lat: 3.1,
                                       long: 3.2,
                                       dock_count: 3,
                                       city_name: "TestCityName3",
                                       installation_date: "2011-11-11",
-                                      csv_id: 3)
+                                      )
+        test_trip1 = Trip.write(duration: 90,
+                                  start_date: "2011-3-6 12:00",
+                                  start_station_name: "TestStation1",
+                                  end_date: "2011-3-6 12:00",
+                                  end_station_name: "TestStation3",
+                                  bike_id: 3,
+                                  subscription_type: "Subscriber", 
+                                  zipcode: 80211)
+        test_trip2 = Trip.write(duration: 100,
+                                  start_date: "2012-2-2 12:00",
+                                  start_station_name: "TestStation10",
+                                  end_date: "2012-2-6 12:00",
+                                  end_station_name: "TestStation3",
+                                  bike_id: 6,
+                                  subscription_type: "Subscriber", 
+                                  zipcode: 80222)
+        test_trip3 = Trip.write(duration: 200,
+                                  start_date: "2013-3-3 12:00",
+                                  start_station_name: "TestStation10",
+                                  end_date: "2013-3-6 12:00",
+                                  end_station_name: "TestStation1",
+                                  bike_id: 4,
+                                  subscription_type: "Subscriber", 
+                                  zipcode: 80333)
 
         expect(Trip.station_with_most_rides_as_starting_place.name).to eq(test_station10.name)
       end
@@ -195,21 +202,12 @@ describe "Trip" do
 
   describe "Database relations" do
     it "Returns Station object for trip start station" do
-      test_trip = Trip.write(duration: 90,
-                                start_date: "2011-3-6 12:00",
-                                start_station_id: 1,
-                                end_date: "2011-3-6 12:00",
-                                end_station_id: 3,
-                                bike_id: 3,
-                                subscription_type: "Subscriber", 
-                                zipcode: 80211)
       test_start_station = Station.write(name: "TestStation1",
                                         lat: 1.1,
                                         long: 1.2,
                                         dock_count: 1,
                                         city_name: "TestCityName1",
                                         installation_date: "2011-11-11",
-                                        csv_id: 1
                                         )
       test_end_station = Station.write(name: "TestStation3",
                                         lat: 3.1,
@@ -217,36 +215,42 @@ describe "Trip" do
                                         dock_count: 3,
                                         city_name: "TestCityName3",
                                         installation_date: "2011-11-11",
-                                        csv_id: 3
                                         )
+      test_trip = Trip.write(duration: 90,
+                            start_date: "2011-3-6 12:00",
+                            start_station_name: "TestStation1",
+                            end_date: "2011-3-6 12:00",
+                            end_station_name: "TestStation3",
+                            bike_id: 3,
+                            subscription_type: "Subscriber", 
+                            zipcode: 80211)
 
       expect(test_trip.start_station.name).to eq(test_start_station.name)
     end
+
     it "Returns Station object for trip end station" do
-      test_trip = Trip.write(duration: 90,
-                                start_date: "2011-3-6 12:00",
-                                start_station_id: 1,
-                                end_date: "2011-3-6 12:00",
-                                end_station_id: 3,
-                                bike_id: 3,
-                                subscription_type: "Subscriber", 
-                                zipcode: 80211)
       test_start_station = Station.write(name: "TestStation1",
                                         lat: 1.1,
                                         long: 1.2,
                                         dock_count: 1,
                                         city_name: "TestCityName1",
                                         installation_date: "2011-11-11",
-                                        csv_id: 1
                                         )
       test_end_station = Station.write(name: "TestStation3",
-                                        lat: 3.1,
-                                        long: 3.2,
-                                        dock_count: 3,
-                                        city_name: "TestCityName3",
-                                        installation_date: "2011-11-11",
-                                        csv_id: 3
-                                        )
+                                      lat: 3.1,
+                                      long: 3.2,
+                                      dock_count: 3,
+                                      city_name: "TestCityName3",
+                                      installation_date: "2011-11-11",
+                                      )
+      test_trip = Trip.write(duration: 90,
+                              start_date: "2011-3-6 12:00",
+                              start_station_name: "TestStation1",
+                              end_date: "2011-3-6 12:00",
+                              end_station_name: "TestStation3",
+                              bike_id: 3,
+                              subscription_type: "Subscriber", 
+                              zipcode: 80211)
 
       expect(test_trip.end_station.name).to eq(test_end_station.name)
     end


### PR DESCRIPTION
This will update the way that Trips stores `start_station_id` and `end_station_id`.

Before, we were storing the `station_id`s directly from the CSV file, but these `id`s did not match the auto-incrementing `id`s that `stations` had. Now, it assigns the `id` by searching by the name, which was thankfully in our csv as well.

There was a little bit of funny stuff with loading the Stations table, so make sure you run `rake db:migrate` and `rake db:test:prepare` to prevent any issues. Phew! This was frustrating, but should make everything else possible.

@Sh1pley @Laszlo-JFLMTCO @MarisaMBurton 