### PR TITLE
Stations table fix with CSV file ID

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,10 +5,12 @@ require "sinatra/activerecord/rake"
 
 namespace :db do
   require_relative "db/seeds"
-  desc "Import CSV to table"
-  task :import_csv => :environment do
-    # import_station_csv
-  
+  desc "Import station.CSV into table"
+  task :import_station_csv => :environment do
+    import_station_csv
+  end
+  desc "Import trip.CSV into table"
+  task :import_trip_csv => :environment do
     import_trip_csv
   end
 end

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -1,5 +1,8 @@
 class Station < ActiveRecord::Base
   belongs_to :city
+  has_many :start_trips , class_name: "Trip", primary_key: "csv_id", foreign_key: "start_station_id"
+  has_many :end_trips , class_name: "Trip", primary_key: "csv_id", foreign_key: "end_station_id"
+
   validates :name, :dock_count, :city_id, :installation_date, presence: true
 
   def self.write(station_details)
@@ -8,7 +11,8 @@ class Station < ActiveRecord::Base
                           long: station_details[:long],
                           dock_count: station_details[:dock_count],
                           city_id: find_city_id(station_details[:city_name]),
-                          installation_date: station_details[:installation_date]
+                          installation_date: station_details[:installation_date],
+                          csv_id: station_details[:csv_id]
                           )
   end
 

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -26,4 +26,10 @@ class Trip < ActiveRecord::Base
     Subscription.write(name: subscription_type).id
   end
 
+  def self.rides_average_duration
+    average(:duration)
+  end
+
+
+
 end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -42,4 +42,16 @@ class Trip < ActiveRecord::Base
     Station.find_by(csv_id: start_station_id)
   end
 
+  def self.most_ridden_bike_with_total_number_of_rides_for_that_bike_all
+    Trip.group(:bike_id).order("count_bike_id desc").count("bike_id")
+  end
+
+  def self.most_ridden_bike_with_total_number_of_rides_for_that_bike
+    bike_ridden_id_count_list = most_ridden_bike_with_total_number_of_rides_for_that_bike_all
+    {
+      :most_ridden_bike_id => bike_ridden_id_count_list.first.first,
+      :total_number_of_rides => bike_ridden_id_count_list.first.last
+    }
+  end
+
 end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -10,6 +10,8 @@ class Trip < ActiveRecord::Base
             :zipcode,
                presence: true
   belongs_to :subscription
+  belongs_to :start_station , class_name: "Station", primary_key: "csv_id", foreign_key: "start_station_id"
+  belongs_to :end_station , class_name: "Station", primary_key: "csv_id", foreign_key: "end_station_id"
 
   def self.write(trip_details)
     self.find_or_create_by(subscription_id: find_subscription_id(trip_details[:subscription_name]),
@@ -29,7 +31,5 @@ class Trip < ActiveRecord::Base
   def self.rides_average_duration
     average(:duration)
   end
-
-
 
 end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -28,8 +28,18 @@ class Trip < ActiveRecord::Base
     Subscription.write(name: subscription_type).id
   end
 
-  def self.rides_average_duration
+  def self.average_duration_of_a_ride
     average(:duration)
+  end
+
+  def self.trip_count_for_stations_as_starting_place_all
+    Trip.group(:start_station_id).order("count_start_station_id desc").count("start_station_id")
+  end
+
+  def self.station_with_most_rides_as_starting_place
+    start_station_id_count_list = trip_count_for_stations_as_starting_place_all
+    start_station_id = start_station_id_count_list.first.first
+    Station.find_by(csv_id: start_station_id)
   end
 
 end

--- a/db/migrate/20161207050055_add_csv_id_column_to_stations.rb
+++ b/db/migrate/20161207050055_add_csv_id_column_to_stations.rb
@@ -1,0 +1,5 @@
+class AddCsvIdColumnToStations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :stations, :csv_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161206232118) do
+ActiveRecord::Schema.define(version: 20161207050055) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 20161206232118) do
     t.date     "installation_date"
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
+    t.integer  "csv_id"
   end
 
   create_table "subscriptions", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,12 +19,14 @@ def import_station_csv
                    long: row["long"],
                    dock_count: row["dock_count"],
                    city_name: row["city"],
-                   installation_date: time_fix(row["installation_date"])})
+                   installation_date: time_fix(row["installation_date"]),
+                   csv_id: row['id']})
   end
   puts "Imported Stations to Table."
 end
 
 def import_trip_csv
+  puts
   CSV.foreach('db/csv/trip.csv', :headers=> true) do |row|
     Trip.write({duration: row['duration'],
                 start_date: time_fix(row['start_date']),

--- a/spec/models/station_spec.rb
+++ b/spec/models/station_spec.rb
@@ -330,4 +330,83 @@ describe "Station" do
       end
     end
   end
+  describe "Database relations" do
+    it "Returns lits of Trip objects where station was start station for trip" do
+      test_trip1 = Trip.write(duration: 90,
+                                start_date: "2011-3-6 12:00",
+                                start_station_id: 1,
+                                end_date: "2011-3-6 12:00",
+                                end_station_id: 3,
+                                bike_id: 3,
+                                subscription_type: "Subscriber", 
+                                zipcode: 80211)
+      test_trip2 = Trip.write(duration: 100,
+                                start_date: "2012-2-2 12:00",
+                                start_station_id: 10,
+                                end_date: "2012-2-6 12:00",
+                                end_station_id: 3,
+                                bike_id: 6,
+                                subscription_type: "Subscriber", 
+                                zipcode: 80222)
+      test_start_station = Station.write(name: "TestStation1",
+                                        lat: 1.1,
+                                        long: 1.2,
+                                        dock_count: 1,
+                                        city_name: "TestCityName1",
+                                        installation_date: "2011-11-11",
+                                        csv_id: 1
+                                        )
+      test_end_station = Station.write(name: "TestStation3",
+                                        lat: 3.1,
+                                        long: 3.2,
+                                        dock_count: 3,
+                                        city_name: "TestCityName3",
+                                        installation_date: "2011-11-11",
+                                        csv_id: 3
+                                        )
+
+      expect(test_start_station.start_trips.count).to eq(1)
+      expect(test_start_station.start_trips.first.duration).to eq(test_trip1.duration)
+    end
+    it "Returns lits of Trip objects where station was end station for trip" do
+      test_trip1 = Trip.write(duration: 90,
+                                start_date: "2011-3-6 12:00",
+                                start_station_id: 1,
+                                end_date: "2011-3-6 12:00",
+                                end_station_id: 3,
+                                bike_id: 3,
+                                subscription_type: "Subscriber", 
+                                zipcode: 80211)
+      test_trip2 = Trip.write(duration: 100,
+                                start_date: "2012-2-2 12:00",
+                                start_station_id: 10,
+                                end_date: "2012-2-6 12:00",
+                                end_station_id: 3,
+                                bike_id: 6,
+                                subscription_type: "Subscriber", 
+                                zipcode: 80222)
+      test_start_station = Station.write(name: "TestStation1",
+                                        lat: 1.1,
+                                        long: 1.2,
+                                        dock_count: 1,
+                                        city_name: "TestCityName1",
+                                        installation_date: "2011-11-11",
+                                        csv_id: 1
+                                        )
+      test_end_station = Station.write(name: "TestStation3",
+                                        lat: 3.1,
+                                        long: 3.2,
+                                        dock_count: 3,
+                                        city_name: "TestCityName3",
+                                        installation_date: "2011-11-11",
+                                        csv_id: 3
+                                        )
+
+      expect(test_end_station.end_trips.count).to eq(2)
+      expect(test_end_station.end_trips.first.duration).to eq(test_trip1.duration)
+      expect(test_end_station.end_trips.last.duration).to eq(test_trip2.duration)
+    end
+
+  end
+
 end

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -117,4 +117,63 @@ describe "Trip" do
     end
   end
 
+  describe "Database relations" do
+    it "Returns Station object for trip start station" do
+      test_trip = Trip.write(duration: 90,
+                                start_date: "2011-3-6 12:00",
+                                start_station_id: 1,
+                                end_date: "2011-3-6 12:00",
+                                end_station_id: 3,
+                                bike_id: 3,
+                                subscription_type: "Subscriber", 
+                                zipcode: 80211)
+      test_start_station = Station.write(name: "TestStation1",
+                                        lat: 1.1,
+                                        long: 1.2,
+                                        dock_count: 1,
+                                        city_name: "TestCityName1",
+                                        installation_date: "2011-11-11",
+                                        csv_id: 1
+                                        )
+      test_end_station = Station.write(name: "TestStation3",
+                                        lat: 3.1,
+                                        long: 3.2,
+                                        dock_count: 3,
+                                        city_name: "TestCityName3",
+                                        installation_date: "2011-11-11",
+                                        csv_id: 3
+                                        )
+
+      expect(test_trip.start_station.name).to eq(test_start_station.name)
+    end
+    it "Returns Station object for trip end station" do
+      test_trip = Trip.write(duration: 90,
+                                start_date: "2011-3-6 12:00",
+                                start_station_id: 1,
+                                end_date: "2011-3-6 12:00",
+                                end_station_id: 3,
+                                bike_id: 3,
+                                subscription_type: "Subscriber", 
+                                zipcode: 80211)
+      test_start_station = Station.write(name: "TestStation1",
+                                        lat: 1.1,
+                                        long: 1.2,
+                                        dock_count: 1,
+                                        city_name: "TestCityName1",
+                                        installation_date: "2011-11-11",
+                                        csv_id: 1
+                                        )
+      test_end_station = Station.write(name: "TestStation3",
+                                        lat: 3.1,
+                                        long: 3.2,
+                                        dock_count: 3,
+                                        city_name: "TestCityName3",
+                                        installation_date: "2011-11-11",
+                                        csv_id: 3
+                                        )
+
+      expect(test_trip.end_station.name).to eq(test_end_station.name)
+    end
+  end
+
 end

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -80,7 +80,7 @@ describe "Trip" do
   describe "Methods" do
     describe "average duration of a ride" do
       it "returns nil when no trips are in database table" do
-        expect(Trip.rides_average_duration).to eq(nil)
+        expect(Trip.average_duration_of_a_ride).to eq(nil)
       end
       it "returns proper value with one entry in database table" do
         test_trip = Trip.write(duration: 90,
@@ -92,7 +92,7 @@ describe "Trip" do
                                   subscription_type: "Subscriber", 
                                   zipcode: 80211)
                                   
-        expect(Trip.rides_average_duration).to eq(90)
+        expect(Trip.average_duration_of_a_ride).to eq(90)
       end
       it "returns proper value with more than one entry in database table" do
         test_trip1 = Trip.write(duration: 90,
@@ -112,7 +112,51 @@ describe "Trip" do
                                   subscription_type: "Subscriber", 
                                   zipcode: 80211)
                                   
-        expect(Trip.rides_average_duration).to eq(67.5)
+        expect(Trip.average_duration_of_a_ride).to eq(67.5)
+      end
+    end
+    describe "stations with most rides as starting place" do
+      it "Return Station object from which most rides started from" do
+        test_trip1 = Trip.write(duration: 90,
+                                  start_date: "2011-3-6 12:00",
+                                  start_station_id: 1,
+                                  end_date: "2011-3-6 12:00",
+                                  end_station_id: 3,
+                                  bike_id: 3,
+                                  subscription_type: "Subscriber", 
+                                  zipcode: 80211)
+        test_trip2 = Trip.write(duration: 100,
+                                  start_date: "2012-2-2 12:00",
+                                  start_station_id: 10,
+                                  end_date: "2012-2-6 12:00",
+                                  end_station_id: 3,
+                                  bike_id: 6,
+                                  subscription_type: "Subscriber", 
+                                  zipcode: 80222)
+        test_trip3 = Trip.write(duration: 200,
+                                  start_date: "2013-3-3 12:00",
+                                  start_station_id: 10,
+                                  end_date: "2013-3-6 12:00",
+                                  end_station_id: 15,
+                                  bike_id: 4,
+                                  subscription_type: "Subscriber", 
+                                  zipcode: 80333)
+        test_station10 = Station.write(name: "TestStation10",
+                                        lat: 1.1,
+                                        long: 1.2,
+                                        dock_count: 10,
+                                        city_name: "TestCityName10",
+                                        installation_date: "2011-11-11",
+                                        csv_id: 10)
+        test_station3 = Station.write(name: "TestStation3",
+                                      lat: 3.1,
+                                      long: 3.2,
+                                      dock_count: 3,
+                                      city_name: "TestCityName3",
+                                      installation_date: "2011-11-11",
+                                      csv_id: 3)
+
+        expect(Trip.station_with_most_rides_as_starting_place.name).to eq(test_station10.name)
       end
     end
   end

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -75,7 +75,46 @@ describe "Trip" do
                                 zipcode: 80211)
       expect(invalid_trip).to_not be_valid
     end
+  end
 
+  describe "Methods" do
+    describe "average duration of a ride" do
+      it "returns nil when no trips are in database table" do
+        expect(Trip.rides_average_duration).to eq(nil)
+      end
+      it "returns proper value with one entry in database table" do
+        test_trip = Trip.write(duration: 90,
+                                  start_date: "2011-3-6 12:00",
+                                  start_station_id: 1,
+                                  end_date: "2011-3-6 12:00",
+                                  end_station_id: 3,
+                                  bike_id: 3,
+                                  subscription_type: "Subscriber", 
+                                  zipcode: 80211)
+                                  
+        expect(Trip.rides_average_duration).to eq(90)
+      end
+      it "returns proper value with more than one entry in database table" do
+        test_trip1 = Trip.write(duration: 90,
+                                  start_date: "2011-3-6 12:00",
+                                  start_station_id: 1,
+                                  end_date: "2011-3-6 12:00",
+                                  end_station_id: 3,
+                                  bike_id: 3,
+                                  subscription_type: "Subscriber", 
+                                  zipcode: 80211)
+        test_trip2 = Trip.write(duration: 45,
+                                  start_date: "2011-6-6 12:00",
+                                  start_station_id: 1,
+                                  end_date: "2011-6-6 12:00",
+                                  end_station_id: 3,
+                                  bike_id: 3,
+                                  subscription_type: "Subscriber", 
+                                  zipcode: 80211)
+                                  
+        expect(Trip.rides_average_duration).to eq(67.5)
+      end
+    end
   end
 
 end

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -78,11 +78,11 @@ describe "Trip" do
   end
 
   describe "Methods" do
-    describe "average duration of a ride" do
-      it "returns nil when no trips are in database table" do
+    describe "Average duration of a ride" do
+      it "Returns nil when no trips are in database table" do
         expect(Trip.average_duration_of_a_ride).to eq(nil)
       end
-      it "returns proper value with one entry in database table" do
+      it "Returns proper value with one entry in database table" do
         test_trip = Trip.write(duration: 90,
                                   start_date: "2011-3-6 12:00",
                                   start_station_id: 1,
@@ -94,7 +94,7 @@ describe "Trip" do
                                   
         expect(Trip.average_duration_of_a_ride).to eq(90)
       end
-      it "returns proper value with more than one entry in database table" do
+      it "Returns proper value with more than one entry in database table" do
         test_trip1 = Trip.write(duration: 90,
                                   start_date: "2011-3-6 12:00",
                                   start_station_id: 1,
@@ -115,7 +115,7 @@ describe "Trip" do
         expect(Trip.average_duration_of_a_ride).to eq(67.5)
       end
     end
-    describe "stations with most rides as starting place" do
+    describe "Stations with most rides as starting place" do
       it "Return Station object from which most rides started from" do
         test_trip1 = Trip.write(duration: 90,
                                   start_date: "2011-3-6 12:00",
@@ -159,6 +159,38 @@ describe "Trip" do
         expect(Trip.station_with_most_rides_as_starting_place.name).to eq(test_station10.name)
       end
     end
+    describe "Most ridden bike with total number of rides for that bike" do
+      it "Returns hash with bike_id and number of rides" do
+        test_trip1 = Trip.write(duration: 90,
+                                  start_date: "2011-3-6 12:00",
+                                  start_station_id: 1,
+                                  end_date: "2011-3-6 12:00",
+                                  end_station_id: 3,
+                                  bike_id: 3,
+                                  subscription_type: "Subscriber", 
+                                  zipcode: 80211)
+        test_trip2 = Trip.write(duration: 100,
+                                  start_date: "2012-2-2 12:00",
+                                  start_station_id: 10,
+                                  end_date: "2012-2-6 12:00",
+                                  end_station_id: 3,
+                                  bike_id: 6,
+                                  subscription_type: "Subscriber", 
+                                  zipcode: 80222)
+        test_trip3 = Trip.write(duration: 200,
+                                  start_date: "2013-3-3 12:00",
+                                  start_station_id: 10,
+                                  end_date: "2013-3-6 12:00",
+                                  end_station_id: 15,
+                                  bike_id: 3,
+                                  subscription_type: "Subscriber", 
+                                  zipcode: 80333)
+
+        expect(Trip.most_ridden_bike_with_total_number_of_rides_for_that_bike[:most_ridden_bike_id]).to eq(3)
+        expect(Trip.most_ridden_bike_with_total_number_of_rides_for_that_bike[:total_number_of_rides]).to eq(2)
+      end
+    end
+
   end
 
   describe "Database relations" do


### PR DESCRIPTION
@wlffann @MarisaMBurton @Sh1pley 
This pull request adds additional column `csv_id` to Stations table. It solve problem of missing station_id link between the Stations and Trips tables.
___IMPORTANT!!!___
I broke up the `rake db:import_csv` task into two separate ones, so we can avoid issues with commenting out one or another method call. This pull request will replace that single import command with two specific ones: `rake db:import_station_csv` and `rake db:import_trip_csv`.
Whenever in doubt, just run `rake --task` for list of available tasks.

This pull request also has the database relations set up:  
* trip objects will have the `.start_station` and `.end_station` methods available to bring in the start and end `Station` objects.  
* station objects will have the `.start_trips` and `.end_trips` methods to provide list of `Trip` objects which referenced the station as `start_station` or `end_station` respectively.

I included model tests as well for all these new methods in the `trip_spec.rb` and 'station_spec.rb` files.